### PR TITLE
Add cartoon track generator start screen

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
 
     implementation(libs.appcompat)
     implementation(libs.material)
+    implementation("androidx.constraintlayout:constraintlayout:2.2.0")
     implementation(libs.games.activity)
     testImplementation(libs.junit)
     androidTestImplementation(libs.ext.junit)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:allowBackup="true"
@@ -19,10 +18,6 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
-            <meta-data
-                android:name="android.app.lib_name"
-                android:value="racingsim" />
         </activity>
     </application>
 

--- a/app/src/main/java/com/example/racingsim/MainActivity.java
+++ b/app/src/main/java/com/example/racingsim/MainActivity.java
@@ -1,32 +1,44 @@
 package com.example.racingsim;
 
-import android.view.View;
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.widget.Button;
+import android.widget.ImageView;
 
-import com.google.androidgamesdk.GameActivity;
+import androidx.appcompat.app.AppCompatActivity;
 
-public class MainActivity extends GameActivity {
-    static {
-        System.loadLibrary("racingsim");
-    }
+import com.example.racingsim.track.TrackData;
+import com.example.racingsim.track.TrackGenerator;
+import com.example.racingsim.track.TrackRenderer;
+
+public class MainActivity extends AppCompatActivity {
+
+    private ImageView trackImageView;
+    private final TrackGenerator trackGenerator = new TrackGenerator();
 
     @Override
-    public void onWindowFocusChanged(boolean hasFocus) {
-        super.onWindowFocusChanged(hasFocus);
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_main);
 
-        if (hasFocus) {
-            hideSystemUi();
-        }
+        trackImageView = findViewById(R.id.trackImageView);
+        Button generateButton = findViewById(R.id.generateButton);
+
+        generateButton.setOnClickListener(v -> generateAndShowTrack());
+        trackImageView.post(this::generateAndShowTrack);
     }
 
-    private void hideSystemUi() {
-        View decorView = getWindow().getDecorView();
-        decorView.setSystemUiVisibility(
-                View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                        | View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                        | View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                        | View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                        | View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                        | View.SYSTEM_UI_FLAG_FULLSCREEN
-        );
+    private void generateAndShowTrack() {
+        int width = trackImageView.getWidth();
+        int height = trackImageView.getHeight();
+
+        if (width <= 0 || height <= 0) {
+            width = getResources().getDisplayMetrics().widthPixels;
+            height = (int) (width * 0.75f);
+        }
+
+        TrackData trackData = trackGenerator.generate(width, height);
+        Bitmap bitmap = TrackRenderer.renderTrack(width, height, trackData);
+        trackImageView.setImageBitmap(bitmap);
     }
 }

--- a/app/src/main/java/com/example/racingsim/track/TrackData.java
+++ b/app/src/main/java/com/example/racingsim/track/TrackData.java
@@ -1,0 +1,47 @@
+package com.example.racingsim.track;
+
+import android.graphics.Path;
+import android.graphics.PointF;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TrackData {
+    private final Path centerlinePath;
+    private final List<PointF> centerlinePoints;
+    private final List<PointF> leftCones;
+    private final List<PointF> rightCones;
+    private final float trackWidth;
+
+    public TrackData(Path centerlinePath,
+                     List<PointF> centerlinePoints,
+                     List<PointF> leftCones,
+                     List<PointF> rightCones,
+                     float trackWidth) {
+        this.centerlinePath = new Path(centerlinePath);
+        this.centerlinePoints = Collections.unmodifiableList(centerlinePoints);
+        this.leftCones = Collections.unmodifiableList(leftCones);
+        this.rightCones = Collections.unmodifiableList(rightCones);
+        this.trackWidth = trackWidth;
+    }
+
+    public Path getCenterlinePath() {
+        return centerlinePath;
+    }
+
+    public List<PointF> getCenterlinePoints() {
+        return centerlinePoints;
+    }
+
+    public List<PointF> getLeftCones() {
+        return leftCones;
+    }
+
+    public List<PointF> getRightCones() {
+        return rightCones;
+    }
+
+    public float getTrackWidth() {
+        return trackWidth;
+    }
+}

--- a/app/src/main/java/com/example/racingsim/track/TrackGenerator.java
+++ b/app/src/main/java/com/example/racingsim/track/TrackGenerator.java
@@ -1,0 +1,178 @@
+package com.example.racingsim.track;
+
+import android.graphics.Path;
+import android.graphics.PointF;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+
+public class TrackGenerator {
+
+    private static final int MIN_CONTROL_POINTS = 8;
+    private static final int MAX_CONTROL_POINTS = 12;
+    private static final int SAMPLES_PER_SEGMENT = 22;
+
+    private final Random random = new Random();
+
+    public TrackData generate(int width, int height) {
+        float minDimen = Math.min(width, height);
+        float cx = width / 2f;
+        float cy = height / 2f;
+
+        List<PointF> controlPoints = createControlPoints(cx, cy, minDimen);
+        List<PointF> centerline = createCenterline(controlPoints);
+        Path centerlinePath = buildPath(centerline);
+
+        float trackWidth = minDimen * 0.22f;
+        float coneSpacing = trackWidth * 0.9f;
+
+        List<PointF> leftCones = new ArrayList<>();
+        List<PointF> rightCones = new ArrayList<>();
+        populateConePositions(centerline, trackWidth, coneSpacing, leftCones, rightCones);
+
+        return new TrackData(centerlinePath,
+                new ArrayList<>(centerline),
+                new ArrayList<>(leftCones),
+                new ArrayList<>(rightCones),
+                trackWidth);
+    }
+
+    private List<PointF> createControlPoints(float cx, float cy, float minDimen) {
+        int count = random.nextInt(MAX_CONTROL_POINTS - MIN_CONTROL_POINTS + 1) + MIN_CONTROL_POINTS;
+        List<Float> angles = new ArrayList<>();
+        for (int i = 0; i < count; i++) {
+            float angle = (float) (random.nextFloat() * Math.PI * 2.0);
+            angles.add(angle);
+        }
+        Collections.sort(angles);
+
+        float minRadius = minDimen * 0.28f;
+        float maxRadius = minDimen * 0.45f;
+
+        List<PointF> points = new ArrayList<>();
+        for (float angle : angles) {
+            float radius = minRadius + random.nextFloat() * (maxRadius - minRadius);
+            float wobble = (random.nextFloat() - 0.5f) * minDimen * 0.04f;
+            float x = cx + (float) Math.cos(angle) * (radius + wobble);
+            float y = cy + (float) Math.sin(angle) * (radius + wobble);
+            points.add(new PointF(x, y));
+        }
+        return points;
+    }
+
+    private List<PointF> createCenterline(List<PointF> controlPoints) {
+        ArrayList<PointF> output = new ArrayList<>();
+        int n = controlPoints.size();
+        for (int i = 0; i < n; i++) {
+            PointF p0 = controlPoints.get((i - 1 + n) % n);
+            PointF p1 = controlPoints.get(i);
+            PointF p2 = controlPoints.get((i + 1) % n);
+            PointF p3 = controlPoints.get((i + 2) % n);
+            for (int step = 0; step < SAMPLES_PER_SEGMENT; step++) {
+                float t = step / (float) SAMPLES_PER_SEGMENT;
+                output.add(catmullRom(p0, p1, p2, p3, t));
+            }
+        }
+        return output;
+    }
+
+    private PointF catmullRom(PointF p0, PointF p1, PointF p2, PointF p3, float t) {
+        float t2 = t * t;
+        float t3 = t2 * t;
+
+        float x = 0.5f * ((2f * p1.x) + (-p0.x + p2.x) * t +
+                (2f * p0.x - 5f * p1.x + 4f * p2.x - p3.x) * t2 +
+                (-p0.x + 3f * p1.x - 3f * p2.x + p3.x) * t3);
+        float y = 0.5f * ((2f * p1.y) + (-p0.y + p2.y) * t +
+                (2f * p0.y - 5f * p1.y + 4f * p2.y - p3.y) * t2 +
+                (-p0.y + 3f * p1.y - 3f * p2.y + p3.y) * t3);
+        return new PointF(x, y);
+    }
+
+    private Path buildPath(List<PointF> points) {
+        Path path = new Path();
+        if (points.isEmpty()) {
+            return path;
+        }
+        PointF first = points.get(0);
+        path.moveTo(first.x, first.y);
+        for (int i = 1; i < points.size(); i++) {
+            PointF point = points.get(i);
+            path.lineTo(point.x, point.y);
+        }
+        path.close();
+        return path;
+    }
+
+    private void populateConePositions(List<PointF> centerline,
+                                       float trackWidth,
+                                       float spacing,
+                                       List<PointF> leftCones,
+                                       List<PointF> rightCones) {
+        if (centerline.isEmpty()) {
+            return;
+        }
+
+        float accumulated = 0f;
+        PointF previous = centerline.get(0);
+        int total = centerline.size();
+        float halfWidth = trackWidth / 2f;
+
+        for (int index = 1; index <= total; index++) {
+            PointF current = centerline.get(index % total);
+            float dx = current.x - previous.x;
+            float dy = current.y - previous.y;
+            float segmentLength = (float) Math.hypot(dx, dy);
+            if (segmentLength < 1e-3f) {
+                continue;
+            }
+
+            while (accumulated + segmentLength >= spacing) {
+                float distanceToNext = spacing - accumulated;
+                float ratio = distanceToNext / segmentLength;
+                float px = previous.x + ratio * dx;
+                float py = previous.y + ratio * dy;
+
+                float tangentX = dx / segmentLength;
+                float tangentY = dy / segmentLength;
+                float normalX = -tangentY;
+                float normalY = tangentX;
+
+                leftCones.add(new PointF(px + normalX * halfWidth, py + normalY * halfWidth));
+                rightCones.add(new PointF(px - normalX * halfWidth, py - normalY * halfWidth));
+
+                previous = new PointF(px, py);
+                dx = current.x - previous.x;
+                dy = current.y - previous.y;
+                segmentLength = (float) Math.hypot(dx, dy);
+                accumulated = 0f;
+            }
+
+            accumulated += segmentLength;
+            previous = current;
+        }
+
+        // Ensure the cones start with the closest pair to the bottom of the screen for visual variety
+        if (!leftCones.isEmpty()) {
+            Comparator<PointF> comparator = Comparator.comparing(point -> point.y);
+            int pivot = 0;
+            for (int i = 1; i < leftCones.size(); i++) {
+                if (comparator.compare(leftCones.get(i), leftCones.get(pivot)) > 0) {
+                    pivot = i;
+                }
+            }
+            rotateLists(leftCones, pivot);
+            rotateLists(rightCones, pivot);
+        }
+    }
+
+    private void rotateLists(List<PointF> points, int pivot) {
+        if (pivot <= 0 || pivot >= points.size()) {
+            return;
+        }
+        Collections.rotate(points, points.size() - pivot);
+    }
+}

--- a/app/src/main/java/com/example/racingsim/track/TrackRenderer.java
+++ b/app/src/main/java/com/example/racingsim/track/TrackRenderer.java
@@ -1,0 +1,155 @@
+package com.example.racingsim.track;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.LinearGradient;
+import android.graphics.Paint;
+import android.graphics.Path;
+import android.graphics.PointF;
+import android.graphics.RadialGradient;
+import android.graphics.Shader;
+
+import java.util.Random;
+
+public final class TrackRenderer {
+
+    private TrackRenderer() {
+    }
+
+    public static Bitmap renderTrack(int width, int height, TrackData data) {
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+
+        drawBackground(canvas, width, height);
+        drawTrack(canvas, data);
+        drawCones(canvas, data);
+        drawSparkles(canvas, width, height);
+
+        return bitmap;
+    }
+
+    private static void drawBackground(Canvas canvas, int width, int height) {
+        Paint gradientPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        Shader gradient = new LinearGradient(
+                0, 0, 0, height,
+                Color.parseColor("#FF6EE7FF"),
+                Color.parseColor("#FFFFD56F"),
+                Shader.TileMode.CLAMP);
+        gradientPaint.setShader(gradient);
+        canvas.drawRect(0, 0, width, height, gradientPaint);
+
+        Paint bubblePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        bubblePaint.setColor(Color.parseColor("#66FFFFFF"));
+        float bubbleRadius = Math.min(width, height) * 0.08f;
+        canvas.drawCircle(width * 0.2f, height * 0.25f, bubbleRadius, bubblePaint);
+        canvas.drawCircle(width * 0.85f, height * 0.3f, bubbleRadius * 0.9f, bubblePaint);
+        canvas.drawCircle(width * 0.12f, height * 0.75f, bubbleRadius * 0.7f, bubblePaint);
+
+        Paint stripePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        stripePaint.setColor(Color.parseColor("#33FFFFFF"));
+        stripePaint.setStrokeWidth(bubbleRadius * 0.6f);
+        stripePaint.setStrokeCap(Paint.Cap.ROUND);
+        canvas.drawLine(width * 0.1f, height * 0.55f, width * 0.3f, height * 0.45f, stripePaint);
+        canvas.drawLine(width * 0.75f, height * 0.7f, width * 0.95f, height * 0.6f, stripePaint);
+    }
+
+    private static void drawTrack(Canvas canvas, TrackData data) {
+        Path path = data.getCenterlinePath();
+        float trackWidth = data.getTrackWidth();
+
+        Paint outlinePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        outlinePaint.setColor(Color.parseColor("#FF2B1A7C"));
+        outlinePaint.setStyle(Paint.Style.STROKE);
+        outlinePaint.setStrokeCap(Paint.Cap.ROUND);
+        outlinePaint.setStrokeJoin(Paint.Join.ROUND);
+        outlinePaint.setStrokeWidth(trackWidth * 1.2f);
+        outlinePaint.setShadowLayer(trackWidth * 0.18f, 0f, trackWidth * 0.12f, Color.parseColor("#5512183D"));
+        canvas.drawPath(path, outlinePaint);
+
+        Paint trackPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        trackPaint.setColor(Color.parseColor("#FF9C6CFF"));
+        trackPaint.setStyle(Paint.Style.STROKE);
+        trackPaint.setStrokeCap(Paint.Cap.ROUND);
+        trackPaint.setStrokeJoin(Paint.Join.ROUND);
+        trackPaint.setStrokeWidth(trackWidth);
+        trackPaint.setShadowLayer(trackWidth * 0.1f, 0f, trackWidth * 0.08f, Color.parseColor("#33271233"));
+        canvas.drawPath(path, trackPaint);
+
+        Paint shinePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        shinePaint.setColor(Color.parseColor("#66FFFFFF"));
+        shinePaint.setStyle(Paint.Style.STROKE);
+        shinePaint.setStrokeCap(Paint.Cap.ROUND);
+        shinePaint.setStrokeJoin(Paint.Join.ROUND);
+        shinePaint.setStrokeWidth(trackWidth * 0.25f);
+        canvas.drawPath(path, shinePaint);
+    }
+
+    private static void drawCones(Canvas canvas, TrackData data) {
+        float coneSize = data.getTrackWidth() * 0.32f;
+        Paint bluePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        bluePaint.setStyle(Paint.Style.FILL);
+        bluePaint.setColor(Color.parseColor("#FF2F68FF"));
+
+        Paint yellowPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        yellowPaint.setStyle(Paint.Style.FILL);
+        yellowPaint.setColor(Color.parseColor("#FFFFE159"));
+
+        Paint outlinePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        outlinePaint.setStyle(Paint.Style.STROKE);
+        outlinePaint.setStrokeWidth(coneSize * 0.2f);
+        outlinePaint.setColor(Color.parseColor("#1A000000"));
+
+        Paint highlightPaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        highlightPaint.setColor(Color.parseColor("#CCFFFFFF"));
+        highlightPaint.setStyle(Paint.Style.FILL);
+
+        for (PointF point : data.getLeftCones()) {
+            drawCone(canvas, point, coneSize, bluePaint, outlinePaint, highlightPaint);
+        }
+        for (PointF point : data.getRightCones()) {
+            drawCone(canvas, point, coneSize, yellowPaint, outlinePaint, highlightPaint);
+        }
+    }
+
+    private static void drawCone(Canvas canvas,
+                                 PointF point,
+                                 float size,
+                                 Paint fillPaint,
+                                 Paint outlinePaint,
+                                 Paint highlightPaint) {
+        Path conePath = new Path();
+        conePath.moveTo(point.x, point.y - size * 1.4f);
+        conePath.lineTo(point.x + size, point.y + size);
+        conePath.lineTo(point.x - size, point.y + size);
+        conePath.close();
+
+        fillPaint.setShadowLayer(size * 0.45f, 0f, size * 0.25f, Color.parseColor("#55000000"));
+        canvas.drawPath(conePath, fillPaint);
+        canvas.drawPath(conePath, outlinePaint);
+
+        canvas.drawCircle(point.x - size * 0.2f, point.y - size * 0.3f, size * 0.35f, highlightPaint);
+    }
+
+    private static void drawSparkles(Canvas canvas, int width, int height) {
+        Paint sparklePaint = new Paint(Paint.ANTI_ALIAS_FLAG);
+        sparklePaint.setStyle(Paint.Style.FILL);
+        Random random = new Random();
+        int count = 30;
+        for (int i = 0; i < count; i++) {
+            float x = random.nextFloat() * width;
+            float y = random.nextFloat() * height;
+            float radius = Math.max(1f, random.nextFloat() * Math.min(width, height) * 0.01f);
+            Shader shader = new RadialGradient(
+                    x,
+                    y,
+                    radius,
+                    new int[]{Color.parseColor("#FFFFFFFF"), Color.parseColor("#00FFFFFF")},
+                    new float[]{0.2f, 1f},
+                    Shader.TileMode.CLAMP);
+            sparklePaint.setShader(shader);
+            canvas.drawCircle(x, y, radius, sparklePaint);
+            sparklePaint.setShader(null);
+        }
+    }
+}

--- a/app/src/main/res/drawable/start_background.xml
+++ b/app/src/main/res/drawable/start_background.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <gradient
+        android:angle="90"
+        android:endColor="#FFFFA726"
+        android:startColor="#FF6C63FF" />
+</shape>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/start_background"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/titleText"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="sans-serif-black"
+        android:text="@string/start_title"
+        android:textColor="@android:color/white"
+        android:textSize="28sp"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/trackImageView"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:layout_marginTop="16dp"
+        android:contentDescription="@string/generated_track_description"
+        android:scaleType="fitCenter"
+        app:layout_constraintBottom_toTopOf="@+id/generateButton"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/titleText" />
+
+    <Button
+        android:id="@+id/generateButton"
+        style="@style/Widget.MaterialComponents.Button"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:backgroundTint="@color/mario_red"
+        android:elevation="6dp"
+        android:fontFamily="sans-serif-medium"
+        android:text="@string/generate_button"
+        android:textAllCaps="false"
+        android:textColor="@android:color/white"
+        android:textSize="18sp"
+        app:cornerRadius="20dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,9 @@
     <color name="teal_700">#FF018786</color>
     <color name="black">#FF000000</color>
     <color name="white">#FFFFFFFF</color>
+    <color name="mario_red">#FFE53935</color>
+    <color name="mario_blue">#FF4285F4</color>
+    <color name="mario_yellow">#FFFFD740</color>
+    <color name="mario_purple">#FF8E24AA</color>
+    <color name="track_shadow">#66121F47</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">RacingSIm</string>
+    <string name="start_title">Kart Track Designer</string>
+    <string name="generate_button">Track generieren</string>
+    <string name="generated_track_description">Bunter Cartoon-Streckenplan mit blauen und gelben Kegeln</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,16 +1,12 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.RacingSIm" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
-        <!-- Primary brand color. -->
+    <style name="Theme.RacingSIm" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>
         <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
         <item name="colorSecondary">@color/teal_200</item>
         <item name="colorSecondaryVariant">@color/teal_700</item>
         <item name="colorOnSecondary">@color/black</item>
-        <!-- Status bar color. -->
-        <item name="android:statusBarColor">?attr/colorPrimaryVariant</item>
-        <!-- Customize your theme here. -->
+        <item name="android:statusBarColor" tools:targetApi="l">@android:color/transparent</item>
     </style>
 </resources>


### PR DESCRIPTION
## Summary
- replace the native entry point with an Android UI that hosts the track preview and generator button
- add a Java-based track generator and renderer that draws a cartoonish circuit with blue and yellow cones
- introduce resources for the start screen layout, gradient background, and bright Mario Kart inspired palette

## Testing
- `./gradlew lint` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d69a410ee8833093393d15cad1dec3