### PR TITLE
Handle JSONException when serialising map points

### DIFF
--- a/app/src/main/java/com/example/racingsim/model/MapPoints.java
+++ b/app/src/main/java/com/example/racingsim/model/MapPoints.java
@@ -61,8 +61,12 @@ public class MapPoints {
         JSONArray array = new JSONArray();
         for (float[] point : points) {
             JSONArray entry = new JSONArray();
-            entry.put(point[0]);
-            entry.put(point[1]);
+            try {
+                entry.put(point[0]);
+                entry.put(point[1]);
+            } catch (JSONException e) {
+                throw new IllegalStateException("Failed to serialise map point", e);
+            }
             array.put(entry);
         }
         return array;


### PR DESCRIPTION
## Summary
- guard MapPoints JSON serialisation against JSONException when populating point arrays
- surface serialization issues as IllegalStateException to match existing error handling

## Testing
- ./gradlew :app:compileDebugJavaWithJavac *(fails: SDK location not configured in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b24952d483309501a456b9431607