### PR TITLE
Ensure track rendering uses final dimensions in background task

### DIFF
--- a/app/src/main/java/com/example/racingsim/MainActivity.java
+++ b/app/src/main/java/com/example/racingsim/MainActivity.java
@@ -55,10 +55,13 @@ public class MainActivity extends AppCompatActivity {
             height = (int) (width * 0.75f);
         }
 
+        final int renderWidth = width;
+        final int renderHeight = height;
+
         final int requestId = generationCounter.incrementAndGet();
         renderExecutor.submit(() -> {
-            TrackData trackData = trackGenerator.generate(width, height);
-            Bitmap bitmap = TrackRenderer.renderTrack(width, height, trackData);
+            TrackData trackData = trackGenerator.generate(renderWidth, renderHeight);
+            Bitmap bitmap = TrackRenderer.renderTrack(renderWidth, renderHeight, trackData);
             mainHandler.post(() -> {
                 if (isDestroyed() || requestId != generationCounter.get()) {
                     bitmap.recycle();


### PR DESCRIPTION
## Summary
- store the computed track dimensions in final variables before submitting the render task
- update background rendering to use the stable dimensions and avoid lambda capture errors

## Testing
- `./gradlew test` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bc14cef88330ad032927d2812f40