### PR TITLE
Adjust minSdk to match available NDK API level

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,7 +8,7 @@ android {
 
     defaultConfig {
         applicationId = "com.example.racingsim"
-        minSdk = 36
+        minSdk = 35
         targetSdk = 36
         versionCode = 1
         versionName = "1.0"


### PR DESCRIPTION
## Summary
- lower the Android minSdk level from 36 to 35 so the native build uses an API level supported by the bundled NDK

## Testing
- ./gradlew assembleDebug *(fails: SDK location not configured in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bd953dc08330b726cf38ea83c7f1