### PR TITLE
Render map cones as cylinders in 3D preview

### DIFF
--- a/app/src/main/java/com/example/racingsim/gl/GeometryFactory.java
+++ b/app/src/main/java/com/example/racingsim/gl/GeometryFactory.java
@@ -122,6 +122,114 @@ public final class GeometryFactory {
         return new Mesh(vertexArray, indexArray, new int[]{3, 3, 3});
     }
 
+    public static Mesh createCylinder(float radius,
+                                      float height,
+                                      int slices,
+                                      Color3f color) {
+        int ringCount = 2;
+        int verticesPerRing = slices + 1;
+        int totalSideVertices = ringCount * verticesPerRing;
+        List<Float> vertices = new ArrayList<>(totalSideVertices * 9);
+
+        float[] ringHeights = new float[]{0f, height};
+        for (int ringIndex = 0; ringIndex < ringCount; ringIndex++) {
+            float currentHeight = ringHeights[ringIndex];
+            for (int slice = 0; slice <= slices; slice++) {
+                float angle = (float) (2.0 * Math.PI * slice / slices);
+                float cos = (float) Math.cos(angle);
+                float sin = (float) Math.sin(angle);
+                float x = radius * cos;
+                float y = radius * sin;
+                float nx = cos;
+                float ny = sin;
+                // Position (x, y, z)
+                vertices.add(x);
+                vertices.add(y);
+                vertices.add(currentHeight);
+                // Normal (x, y, z)
+                vertices.add(nx);
+                vertices.add(ny);
+                vertices.add(0f);
+                // Color (r, g, b)
+                vertices.add(color.r);
+                vertices.add(color.g);
+                vertices.add(color.b);
+            }
+        }
+
+        List<Short> indices = new ArrayList<>(slices * (ringCount - 1) * 6 + slices * 6);
+        for (int ring = 0; ring < ringCount - 1; ring++) {
+            int ringStart = ring * verticesPerRing;
+            int nextRingStart = (ring + 1) * verticesPerRing;
+            for (int slice = 0; slice < slices; slice++) {
+                short current = (short) (ringStart + slice);
+                short next = (short) (ringStart + slice + 1);
+                short upper = (short) (nextRingStart + slice);
+                short upperNext = (short) (nextRingStart + slice + 1);
+
+                indices.add(current);
+                indices.add(upper);
+                indices.add(upperNext);
+
+                indices.add(current);
+                indices.add(upperNext);
+                indices.add(next);
+            }
+        }
+
+        // Bottom disc (downward normal)
+        short bottomCenterIndex = (short) (totalSideVertices);
+        vertices.add(0f);
+        vertices.add(0f);
+        vertices.add(0f);
+        vertices.add(0f);
+        vertices.add(0f);
+        vertices.add(-1f);
+        vertices.add(color.r);
+        vertices.add(color.g);
+        vertices.add(color.b);
+
+        for (int slice = 0; slice < slices; slice++) {
+            short current = (short) slice;
+            short next = (short) (slice + 1);
+            indices.add(bottomCenterIndex);
+            indices.add(next);
+            indices.add(current);
+        }
+
+        // Top disc (upward normal)
+        short topCenterIndex = (short) (totalSideVertices + 1);
+        vertices.add(0f);
+        vertices.add(0f);
+        vertices.add(height);
+        vertices.add(0f);
+        vertices.add(0f);
+        vertices.add(1f);
+        vertices.add(color.r);
+        vertices.add(color.g);
+        vertices.add(color.b);
+
+        int topRingStart = verticesPerRing;
+        for (int slice = 0; slice < slices; slice++) {
+            short current = (short) (topRingStart + slice);
+            short next = (short) (topRingStart + slice + 1);
+            indices.add(topCenterIndex);
+            indices.add(current);
+            indices.add(next);
+        }
+
+        float[] vertexArray = new float[vertices.size()];
+        for (int i = 0; i < vertices.size(); i++) {
+            vertexArray[i] = vertices.get(i);
+        }
+        short[] indexArray = new short[indices.size()];
+        for (int i = 0; i < indices.size(); i++) {
+            indexArray[i] = indices.get(i);
+        }
+
+        return new Mesh(vertexArray, indexArray, new int[]{3, 3, 3});
+    }
+
     private static Color3f selectColorForHeight(float height,
                                                 float stripeLower,
                                                 float stripeUpper,

--- a/app/src/main/java/com/example/racingsim/gl/Map3DRenderer.java
+++ b/app/src/main/java/com/example/racingsim/gl/Map3DRenderer.java
@@ -15,15 +15,13 @@ import javax.microedition.khronos.egl.EGLConfig;
 import javax.microedition.khronos.opengles.GL10;
 
 /**
- * Renderer responsible for drawing the ground, cones and the billboard car preview.
+ * Renderer responsible for drawing the ground, cylinders and the billboard car preview.
  */
 public class Map3DRenderer implements GLSurfaceView.Renderer {
 
-    private static final float CONE_HEIGHT_M = 0.45f;
-    private static final float CONE_RADIUS_M = 0.115f;
-    private static final int CONE_SLICES = 32;
-    private static final float STRIPE_CENTER_RATIO = 0.25f;
-    private static final float STRIPE_HEIGHT_RATIO = 0.06f;
+    private static final float CYLINDER_HEIGHT_M = 0.45f;
+    private static final float CYLINDER_RADIUS_M = 0.115f;
+    private static final int CYLINDER_SLICES = 32;
 
     private static final float CAR_WIDTH_M = 1.6f;
     private static final float CAR_HEIGHT_M = 1.2f;
@@ -50,8 +48,8 @@ public class Map3DRenderer implements GLSurfaceView.Renderer {
     private ShaderProgram colorProgram;
     private TexturedProgram texturedProgram;
 
-    private Mesh blueConeMesh;
-    private Mesh yellowConeMesh;
+    private Mesh blueCylinderMesh;
+    private Mesh yellowCylinderMesh;
     private Mesh groundMesh;
     private Mesh carBillboardMesh;
 
@@ -205,18 +203,13 @@ public class Map3DRenderer implements GLSurfaceView.Renderer {
         textureAttributeLocations[1] = texturedProgram.getTexCoordAttribute();
 
         GeometryFactory.Color3f blueBody = new GeometryFactory.Color3f(0.0f, 0.35f, 0.9f);
-        GeometryFactory.Color3f blueStripe = new GeometryFactory.Color3f(1f, 1f, 1f);
         GeometryFactory.Color3f yellowBody = new GeometryFactory.Color3f(0.95f, 0.8f, 0.05f);
-        GeometryFactory.Color3f yellowStripe = new GeometryFactory.Color3f(0f, 0f, 0f);
         GeometryFactory.Color3f groundColor = new GeometryFactory.Color3f(0.1f, 0.1f, 0.12f);
 
-        float stripeCenter = CONE_HEIGHT_M * STRIPE_CENTER_RATIO;
-        float stripeHeight = CONE_HEIGHT_M * STRIPE_HEIGHT_RATIO;
-
-        blueConeMesh = GeometryFactory.createConeWithStripe(CONE_RADIUS_M, CONE_HEIGHT_M, CONE_SLICES,
-                stripeCenter, stripeHeight, blueBody, blueStripe);
-        yellowConeMesh = GeometryFactory.createConeWithStripe(CONE_RADIUS_M, CONE_HEIGHT_M, CONE_SLICES,
-                stripeCenter, stripeHeight, yellowBody, yellowStripe);
+        blueCylinderMesh = GeometryFactory.createCylinder(CYLINDER_RADIUS_M, CYLINDER_HEIGHT_M,
+                CYLINDER_SLICES, blueBody);
+        yellowCylinderMesh = GeometryFactory.createCylinder(CYLINDER_RADIUS_M, CYLINDER_HEIGHT_M,
+                CYLINDER_SLICES, yellowBody);
         groundMesh = GeometryFactory.createGround(sceneRadius * 2f, groundColor);
         carBillboardMesh = GeometryFactory.createTexturedQuad(CAR_WIDTH_M, CAR_HEIGHT_M);
 
@@ -254,8 +247,8 @@ public class Map3DRenderer implements GLSurfaceView.Renderer {
         Matrix.multiplyMM(viewProjectionMatrix, 0, projectionMatrix, 0, viewMatrix, 0);
 
         drawGround();
-        drawCones(blueConeMesh, bluePoints);
-        drawCones(yellowConeMesh, yellowPoints);
+        drawCylinders(blueCylinderMesh, bluePoints);
+        drawCylinders(yellowCylinderMesh, yellowPoints);
         drawCarBillboard(yaw);
     }
 
@@ -270,7 +263,7 @@ public class Map3DRenderer implements GLSurfaceView.Renderer {
         groundMesh.draw(GLES20.GL_TRIANGLES, colorAttributeLocations);
     }
 
-    private void drawCones(Mesh mesh, List<float[]> points) {
+    private void drawCylinders(Mesh mesh, List<float[]> points) {
         colorProgram.use();
         GLES20.glUniform3f(colorLightDirectionLocation, normalizedLightDirection[0],
                 normalizedLightDirection[1], normalizedLightDirection[2]);


### PR DESCRIPTION
## Summary
- replace the 3D preview cone meshes with solid blue and yellow cylinders that match the 2D map colors
- add a reusable cylinder mesh generator to the geometry factory for drawing the new markers

## Testing
- ./gradlew test *(fails: Android SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da597d011c8330afe97a63a1472944